### PR TITLE
Updated DASH API

### DIFF
--- a/videoserver/templates/video_player.html
+++ b/videoserver/templates/video_player.html
@@ -64,8 +64,8 @@
                 headers: {
                     "X-489-UUID": uuid,
                     "X-Fragment-Size": e.response.byteLength,
-                    "X-Timestamp-Start": e.request.requestStartDate.getTime(),
-                    "X-Timestamp-End": e.request.requestEndDate.getTime(),
+                    "X-Timestamp-Start": e.request.startDate.getTime(),
+                    "X-Timestamp-End": e.request.endDate.getTime(),
                     "Content-Length": 0,
                 },
             }).catch(error => {


### PR DESCRIPTION
The following issue was causing an error running the video. DASH API needed to be updated to reflect the reflect object.